### PR TITLE
Back off one more epoch for metrics test on head

### DIFF
--- a/cmd/invariants/metrics.go
+++ b/cmd/invariants/metrics.go
@@ -38,7 +38,7 @@ var metricsCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			epoch = epoch - 2
+			epoch = epoch - 3
 		}
 
 		checkMinerCount, err := cmd.Flags().GetBool("miner-count")


### PR DESCRIPTION
It was failing occassionally on GitHub Actions, likely due to null rounds.