### PR TITLE
Remove accidentally checked in hack for binary search

### DIFF
--- a/cmd/invariants/agentbalances.go
+++ b/cmd/invariants/agentbalances.go
@@ -261,6 +261,7 @@ func binarySearch(
 	goodIdx int,
 	badIdx int,
 ) {
+	// goodIdx = max(goodIdx, 231)
 	fmt.Printf("Binary searching between %d and %d\n", goodIdx, badIdx)
 	searchIdx := (goodIdx + badIdx) / 2
 	if searchIdx == goodIdx || searchIdx == badIdx {


### PR DESCRIPTION
This was added for a specific case to skip over a false failure (due to multiple transactions at the same epoch) to find some transactions.

This breaks the binary search for other cases, so this removes the hack.