### PR TITLE
Group CLI commands by domain (agent/pool/miner)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 SETENV
 *.env
 /invariants
+/inv
 

--- a/cmd/invariants/agent.go
+++ b/cmd/invariants/agent.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// agentCmd is the parent of every agent-level invariant check.
+//
+// Without a subcommand it runs every child check in sequence with
+// `--all` set so an operator can see the whole agent picture in one
+// invocation. With a subcommand (`inv agent balances`, `inv agent
+// econ`, ...) it behaves like cobra normally would and just runs that
+// child.
+//
+// The flat names (`inv agent-balances`, `inv agent-econ`) are kept
+// alongside as deprecated aliases for one or two releases so existing
+// scripts keep working.
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Agent-level invariant checks",
+	Long: `Run every agent-level invariant check in sequence, or invoke a
+specific check via a subcommand:
+
+  inv agent              # all agent checks, --all mode
+  inv agent balances 97  # available-balance check for agent 97
+  inv agent econ --all   # debt + LV for every agent`,
+	Run: runAgentAll,
+}
+
+// runAgentAll execs each child as a subprocess so a log.Fatal in one
+// check doesn't stop the others. Children inherit stdout/stderr so
+// output streams live.
+func runAgentAll(cmd *cobra.Command, _ []string) {
+	var failed []string
+	for _, child := range cmd.Commands() {
+		if child.Name() == "help" {
+			continue
+		}
+		fmt.Printf("\n=== inv agent %s ===\n", child.Name())
+		args := []string{"agent", child.Name()}
+		if f := child.Flags().Lookup("all"); f != nil && !f.Changed {
+			args = append(args, "--all")
+		}
+		c := exec.CommandContext(cmd.Context(), os.Args[0], args...)
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		c.Stdin = os.Stdin
+		if err := c.Run(); err != nil {
+			failed = append(failed, child.Name())
+		}
+	}
+	if len(failed) > 0 {
+		fmt.Printf("\n=== FAILED: %v ===\n", failed)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(agentCmd)
+}

--- a/cmd/invariants/agentbalances.go
+++ b/cmd/invariants/agentbalances.go
@@ -6,7 +6,10 @@ import (
 	"log"
 	"math/big"
 	"math/rand"
+	"sort"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/glifio/invariants"
 	"github.com/glifio/invariants/singleton"
@@ -14,121 +17,253 @@ import (
 	"github.com/spf13/viper"
 )
 
-// agentBalancesCmd represents the checkAgentBalance command
-var agentBalancesCmd = &cobra.Command{
-	Use:   "agent-balances [agent-id] [--all] [--random <num>] [--epoch <epoch>]",
-	Short: "Compare the balances from the API and the node for an agent",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
+// newAgentBalancesCmd builds a fresh cobra.Command for the agent
+// balance check. We construct it via a factory so the same logic can
+// be registered both at the deprecated flat name (`inv agent-balances`)
+// and under the `agent` subcommand group (`inv agent balances`).
+func newAgentBalancesCmd(use string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Compare the balances from the API and the node for an agent",
+		Args:  cobra.MaximumNArgs(1),
+		Run:   runAgentBalances,
+	}
+	cmd.Flags().Uint64("epoch", 0, "Check at epoch")
+	cmd.Flags().Uint64("random", 0, "Randomly select agents")
+	cmd.Flags().Bool("all", false, "Check all agents")
+	cmd.Flags().Uint64("max-lookback", 30000, "Skip transactions older than head minus this many epochs (0 disables). dRPC caps state-tree access at ~14d (~40k epochs); 30k gives a safety margin.")
+	cmd.Flags().Uint64("parallel", 8, "Number of agents to check concurrently (--all / --random)")
+	return cmd
+}
 
-		eventsURL := viper.GetString("events_api")
+func runAgentBalances(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
 
-		err := initSingleton(ctx)
+	eventsURL := viper.GetString("events_api")
+
+	err := initSingleton(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	epoch, err := cmd.Flags().GetUint64("epoch")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	allAgents, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	randomAgents, err := cmd.Flags().GetUint64("random")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	maxLookback, err := cmd.Flags().GetUint64("max-lookback")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	parallel, err := cmd.Flags().GetUint64("parallel")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if parallel == 0 {
+		parallel = 1
+	}
+
+	var failCount int
+
+	if !allAgents && randomAgents == 0 {
+		if len(args) != 1 {
+			cmd.Usage()
+			return
+		}
+
+		agentID, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		epoch, err := cmd.Flags().GetUint64("epoch")
+		agent, err := invariants.GetAgentFromAPI(ctx, eventsURL, agentID)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		allAgents, err := cmd.Flags().GetBool("all")
+		failed, err := checkAgentBalance(ctx, eventsURL, epoch, maxLookback, agent)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if failed {
+			failCount++
+		}
+	} else {
+		if len(args) != 0 {
+			cmd.Usage()
+			return
+		}
+
+		agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		randomAgents, err := cmd.Flags().GetUint64("random")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		var failCount int
-
-		if !allAgents && randomAgents == 0 {
-			if len(args) != 1 {
-				cmd.Usage()
-				return
-			}
-
-			agentID, err := strconv.ParseUint(args[0], 10, 64)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			agent, err := invariants.GetAgentFromAPI(ctx, eventsURL, agentID)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			failed, err := checkAgentBalance(ctx, eventsURL, epoch, agent)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if failed {
-				failCount++
-			}
-		} else {
-			if len(args) != 0 {
-				cmd.Usage()
-				return
-			}
-
-			agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
-			if err != nil {
-				log.Fatal(err)
-			}
-
+		if randomAgents > 0 {
 			if allAgents {
-				if randomAgents > 0 {
-					cmd.Usage()
-					return
-				}
-				for _, agent := range agents {
-					failed, err := checkAgentBalance(ctx, eventsURL, epoch, &agent)
-					if err != nil {
-						log.Fatal(err)
-					}
-					if failed {
-						failCount++
-					}
-				}
-			} else if randomAgents > 0 {
-				if int(randomAgents) > len(agents) {
-					randomAgents = uint64(len(agents))
-				}
-				rand.Shuffle(len(agents), func(i, j int) {
-					agents[i], agents[j] = agents[j], agents[i]
-				})
-				for i := 0; i < int(randomAgents); i++ {
-					agent := agents[i]
-					failed, err := checkAgentBalance(ctx, eventsURL, epoch, &agent)
-					if err != nil {
-						log.Fatal(err)
-					}
-					if failed {
-						failCount++
-					}
-				}
-			} else {
 				cmd.Usage()
+				return
 			}
+			if int(randomAgents) > len(agents) {
+				randomAgents = uint64(len(agents))
+			}
+			rand.Shuffle(len(agents), func(i, j int) {
+				agents[i], agents[j] = agents[j], agents[i]
+			})
+			agents = agents[:randomAgents]
+		} else if !allAgents {
+			cmd.Usage()
+			return
 		}
-		if failCount > 0 {
-			log.Fatal("FAIL: Agent balances test had errors.")
+
+		// Snapshot a single epoch upfront and pin every check to
+		// it: prevents per-agent drift between the node and DB
+		// sides as the chain advances during the run. head-3 is
+		// safely past the FEVM event-index lag at head.
+		pinned := epoch
+		if pinned == 0 {
+			head, herr := getHeadEpoch(ctx)
+			if herr != nil {
+				log.Fatalf("get head: %v", herr)
+			}
+			if head < 3 {
+				log.Fatalf("head epoch %d too low to pin", head)
+			}
+			pinned = head - 3
 		}
-	},
+
+		fmt.Printf("agent-balances: %d agents pinned at epoch=%d, parallel=%d\n",
+			len(agents), pinned, parallel)
+		failCount = checkAgentBalancesParallel(ctx, eventsURL, pinned, parallel, agents)
+	}
+	if failCount > 0 {
+		log.Fatal("FAIL: Agent balances test had errors.")
+	}
 }
 
 func init() {
-	rootCmd.AddCommand(agentBalancesCmd)
-	agentBalancesCmd.Flags().Uint64("epoch", 0, "Check at epoch")
-	agentBalancesCmd.Flags().Uint64("random", 0, "Randomly select agents")
-	agentBalancesCmd.Flags().Bool("all", false, "Check all agents")
+	// Deprecated flat name: `inv agent-balances`
+	flat := newAgentBalancesCmd("agent-balances [agent-id] [--all] [--random <num>] [--epoch <epoch>]")
+	flat.Deprecated = "use `inv agent balances` instead"
+	rootCmd.AddCommand(flat)
+	// Grouped: `inv agent balances`
+	agentCmd.AddCommand(newAgentBalancesCmd("balances [agent-id] [--all] [--random <num>] [--epoch <epoch>]"))
 }
 
-func checkAgentBalance(ctx context.Context, eventsURL string, epoch uint64, agent *invariants.Agent) (failed bool, err error) {
+// checkAgentBalancesParallel runs the at-pinned-epoch comparison for
+// every agent in `agents` across `parallel` goroutines. Returns the
+// number of agents that failed (chain-vs-DB mismatch or RPC error).
+//
+// Pinning to a single epoch means both the node side
+// (q.AgentLiquidAssets at epoch+1) and the DB side
+// (/agent/{id}/available-balance?height=epoch) see the same chain
+// state, eliminating per-agent drift the sequential loop produced
+// when the chain advanced mid-run.
+func checkAgentBalancesParallel(
+	ctx context.Context,
+	eventsURL string,
+	epoch uint64,
+	parallel uint64,
+	agents []invariants.Agent,
+) (failCount int) {
+	type result struct {
+		agentID  uint64
+		dbBal    *big.Int
+		ndBal    *big.Int
+		diff     *big.Int
+		err      error
+		duration time.Duration
+	}
+
+	jobs := make(chan invariants.Agent, len(agents))
+	results := make(chan result, len(agents))
+
+	startedAt := time.Now()
+	var wg sync.WaitGroup
+	for w := uint64(0); w < parallel; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for a := range jobs {
+				t0 := time.Now()
+				r := result{agentID: a.ID}
+				dbBal, err := invariants.GetAgentAvailableBalanceAtHeightFromAPI(ctx, eventsURL, a.ID, epoch)
+				if err != nil {
+					r.err = fmt.Errorf("API at h=%d: %w", epoch, err)
+					r.duration = time.Since(t0)
+					results <- r
+					continue
+				}
+				ndBal, _, err := getLiquidAssetsAtHeight(ctx, &a, epoch)
+				if err != nil {
+					r.err = fmt.Errorf("node at h=%d: %w", epoch, err)
+					r.duration = time.Since(t0)
+					results <- r
+					continue
+				}
+				r.dbBal = dbBal
+				r.ndBal = ndBal
+				r.diff = new(big.Int).Sub(dbBal, ndBal)
+				r.duration = time.Since(t0)
+				results <- r
+			}
+		}()
+	}
+
+	for _, a := range agents {
+		jobs <- a
+	}
+	close(jobs)
+	wg.Wait()
+	close(results)
+
+	collected := make([]result, 0, len(agents))
+	for r := range results {
+		collected = append(collected, r)
+	}
+	sort.Slice(collected, func(i, j int) bool { return collected[i].agentID < collected[j].agentID })
+
+	var diffsAbs []*big.Int
+	for _, r := range collected {
+		if r.err != nil {
+			fmt.Printf("Agent %d: ERROR %v\n", r.agentID, r.err)
+			failCount++
+			continue
+		}
+		if r.diff.Sign() == 0 {
+			continue
+		}
+		failCount++
+		fmt.Printf("Agent %d: MISMATCH node=%s api=%s diff=%s\n",
+			r.agentID, r.ndBal.String(), r.dbBal.String(), r.diff.String())
+		diffsAbs = append(diffsAbs, new(big.Int).Abs(r.diff))
+	}
+
+	elapsed := time.Since(startedAt).Round(time.Millisecond)
+	fmt.Printf("\nagent-balances summary: %d/%d failed @ epoch=%d in %s",
+		failCount, len(agents), epoch, elapsed)
+	if len(diffsAbs) > 0 {
+		sort.Slice(diffsAbs, func(i, j int) bool { return diffsAbs[i].Cmp(diffsAbs[j]) < 0 })
+		max := diffsAbs[len(diffsAbs)-1]
+		p95 := diffsAbs[(len(diffsAbs)-1)*95/100]
+		fmt.Printf(" maxDiff=%s p95Diff=%s", max.String(), p95.String())
+	}
+	fmt.Println()
+	return failCount
+}
+
+func checkAgentBalance(ctx context.Context, eventsURL string, epoch uint64, maxLookback uint64, agent *invariants.Agent) (failed bool, err error) {
 	agentID := agent.ID
 	if epoch == 0 {
 		availableBalanceResult, err := invariants.GetAgentAvailableBalanceFromAPI(ctx, eventsURL, agentID)
@@ -144,7 +279,7 @@ func checkAgentBalance(ctx context.Context, eventsURL string, epoch uint64, agen
 		fmt.Printf("Agent %d: Error, latest available balance from REST API doesn't match node.\n", agentID)
 		fmt.Printf("  Node: %v\n", availableBalanceResult.AvailableBalanceNd)
 		fmt.Printf("   API: %v\n", availableBalanceResult.AvailableBalanceDB)
-		examineTransactionHistory(ctx, eventsURL, agent)
+		examineTransactionHistory(ctx, eventsURL, maxLookback, agent)
 	} else {
 		availableBalance, err := invariants.GetAgentAvailableBalanceAtHeightFromAPI(ctx, eventsURL, agentID, epoch)
 		if err != nil {
@@ -156,15 +291,18 @@ func checkAgentBalance(ctx context.Context, eventsURL string, epoch uint64, agen
 			return true, err
 		}
 
-		liquidAssets, err := getLiquidAssetsAtHeight(ctx, agent, epoch)
+		liquidAssets, interest, err := getLiquidAssetsAtHeight(ctx, agent, epoch)
 		if err != nil {
 			return true, err
 		}
+
+		fmt.Printf("Agent %d interest %d\n: ", agentID, interest)
 
 		if availableBalance.Cmp(liquidAssets) == 0 {
 			fmt.Printf("Agent %d @%d: Success, latest available balances match: %v\n", agentID, epoch, availableBalance)
 			return false, nil
 		}
+
 		fmt.Printf("Agent %d @%d: Error, available balance from REST API doesn't match node.\n", agentID, epoch)
 		fmt.Printf("  Node: %v\n", liquidAssets)
 		fmt.Printf("   API: %v\n", availableBalance)
@@ -172,14 +310,74 @@ func checkAgentBalance(ctx context.Context, eventsURL string, epoch uint64, agen
 	return true, nil
 }
 
-func examineTransactionHistory(ctx context.Context, eventsURL string, agent *invariants.Agent) {
+func checkAgentAcruedInterest(ctx context.Context, eventsURL string, epoch uint64, agent *invariants.Agent) (failed bool, err error) {
+	agentID := agent.ID
+
+	q := singleton.PoolsSDK.Query()
+
+	interest, err := q.AgentInterestOwed(ctx, agent.AddressNative, big.NewInt(int64(epoch)))
+	if err != nil {
+		return true, err
+	}
+
+	availableBalance, err := invariants.GetAgentAvailableBalanceAtHeightFromAPI(ctx, eventsURL, agentID, epoch)
+	if err != nil {
+		return true, err
+	}
+
+	agent1, err := invariants.GetAgentFromAPI(ctx, eventsURL, agentID)
+	if err != nil {
+		return true, err
+	}
+
+	liquidAssets, interest, err := getLiquidAssetsAtHeight(ctx, agent1, epoch)
+	if err != nil {
+		return true, err
+	}
+
+	fmt.Printf("Agent %d interest %d\n: ", agentID, interest)
+
+	if availableBalance.Cmp(liquidAssets) == 0 {
+		fmt.Printf("Agent %d @%d: Success, latest available balances match: %v\n", agentID, epoch, availableBalance)
+		return false, nil
+	}
+
+	fmt.Printf("Agent %d @%d: Error, available balance from REST API doesn't match node.\n", agentID, epoch)
+	fmt.Printf("  Node: %v\n", liquidAssets)
+	fmt.Printf("   API: %v\n", availableBalance)
+
+	return true, nil
+}
+
+func examineTransactionHistory(ctx context.Context, eventsURL string, maxLookback uint64, agent *invariants.Agent) {
 	agentID := agent.ID
 	fmt.Println("Examining transaction history...")
 	txs, err := invariants.GetAgentTransactionsFromAPI(ctx, eventsURL, agentID)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("%d transactions retrieved from REST API\n", len(txs))
+	totalTxs := len(txs)
+	fmt.Printf("%d transactions retrieved from REST API\n", totalTxs)
+
+	if maxLookback > 0 && totalTxs > 0 {
+		head, err := getHeadEpoch(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		var floor uint64
+		if head > maxLookback {
+			floor = head - maxLookback
+		}
+		firstUsable := 0
+		for firstUsable < len(txs) && txs[firstUsable].Height < floor {
+			firstUsable++
+		}
+		if firstUsable > 0 {
+			fmt.Printf("Skipping %d of %d transactions older than epoch %d (max-lookback %d)\n",
+				firstUsable, totalTxs, floor, maxLookback)
+			txs = txs[firstUsable:]
+		}
+	}
 	if len(txs) == 0 {
 		fmt.Println("No transactions in db.")
 		txs = append(txs, invariants.Transaction{Height: agent.Height, AvailableBalance: big.NewInt(0)})
@@ -188,7 +386,7 @@ func examineTransactionHistory(ctx context.Context, eventsURL string, agent *inv
 			log.Fatal(err)
 		}
 		height = height - 2
-		liquidAssets, err := getLiquidAssetsAtHeight(ctx, agent, height)
+		liquidAssets, _, err := getLiquidAssetsAtHeight(ctx, agent, height)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -199,14 +397,14 @@ func examineTransactionHistory(ctx context.Context, eventsURL string, agent *inv
 		tx := txs[0]
 		firstIdx := 0
 		fmt.Printf("First tx (idx:0) @%d: ", tx.Height)
-		liquidAssets, err := getLiquidAssetsAtHeight(ctx, agent, tx.Height)
+		liquidAssets, _, err := getLiquidAssetsAtHeight(ctx, agent, tx.Height)
 		if err != nil {
 			log.Fatal(err)
 		}
 		if tx.AvailableBalance.Cmp(liquidAssets) == 0 {
 			fmt.Printf("Matches: %v\n", liquidAssets)
 		} else {
-			fmt.Printf("Mismatch! Node: %v API: %v\n", liquidAssets, tx.AvailableBalance)
+			fmt.Printf("Mismatch! Node: %v API: %v, Diff %v\n", liquidAssets, tx.AvailableBalance, tx.AvailableBalance.Sub(liquidAssets, tx.AvailableBalance))
 			firstTx := invariants.Transaction{Height: agent.Height, AvailableBalance: big.NewInt(0)}
 			txs = append([]invariants.Transaction{firstTx}, txs...)
 			binarySearch(ctx, agent, txs, 0, 1)
@@ -221,7 +419,7 @@ func examineTransactionHistory(ctx context.Context, eventsURL string, agent *inv
 				log.Fatal(err)
 			}
 			height = height - 3
-			liquidAssets, err := getLiquidAssetsAtHeight(ctx, agent, height)
+			liquidAssets, _, err := getLiquidAssetsAtHeight(ctx, agent, height)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -233,7 +431,7 @@ func examineTransactionHistory(ctx context.Context, eventsURL string, agent *inv
 		tx = txs[idx]
 		lastIdx := idx
 		fmt.Printf("Last tx (idx:%d) @%d: ", idx, tx.Height)
-		liquidAssets, err = getLiquidAssetsAtHeight(ctx, agent, tx.Height)
+		liquidAssets, _, err = getLiquidAssetsAtHeight(ctx, agent, tx.Height)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -248,7 +446,7 @@ func examineTransactionHistory(ctx context.Context, eventsURL string, agent *inv
 			binarySearch(ctx, agent, txs, idx, len(txs)-1)
 			return
 		} else {
-			fmt.Printf("Mismatch! Node: %v API: %v\n", liquidAssets, tx.AvailableBalance)
+			fmt.Printf("Mismatch! Node: %v API: %v, Diff: %v\n", liquidAssets, tx.AvailableBalance, tx.AvailableBalance.Sub(liquidAssets, tx.AvailableBalance))
 			binarySearch(ctx, agent, txs, firstIdx, lastIdx)
 		}
 	}
@@ -271,7 +469,7 @@ func binarySearch(
 	}
 	tx := txs[searchIdx]
 	fmt.Printf("Tx (idx:%d) @%d: ", searchIdx, tx.Height)
-	liquidAssets, err := getLiquidAssetsAtHeight(ctx, agent, tx.Height)
+	liquidAssets, _, err := getLiquidAssetsAtHeight(ctx, agent, tx.Height)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -279,7 +477,7 @@ func binarySearch(
 		fmt.Printf("Matches: %v\n", liquidAssets)
 		binarySearch(ctx, agent, txs, searchIdx, badIdx)
 	} else {
-		fmt.Printf("Mismatch! Node: %v API: %v\n", liquidAssets, tx.AvailableBalance)
+		fmt.Printf("Mismatch! Node: %v API: %v, Diff: %v\n", liquidAssets, tx.AvailableBalance, tx.AvailableBalance.Sub(liquidAssets, tx.AvailableBalance))
 		binarySearch(ctx, agent, txs, goodIdx, searchIdx)
 	}
 }
@@ -319,7 +517,7 @@ func findNextBalanceTransition(
 	}
 	fmt.Printf("  Searching %d to %d\n", minHeight, maxHeight)
 	sampleHeight := (maxHeight-minHeight)/2 + minHeight
-	liquidAssets, err := getLiquidAssetsAtHeight(ctx, agent, sampleHeight)
+	liquidAssets, _, err := getLiquidAssetsAtHeight(ctx, agent, sampleHeight)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -339,17 +537,22 @@ func findNextBalanceTransition(
 	}
 }
 
-func getLiquidAssetsAtHeight(ctx context.Context, agent *invariants.Agent, height uint64) (*big.Int, error) {
+func getLiquidAssetsAtHeight(ctx context.Context, agent *invariants.Agent, height uint64) (*big.Int, *big.Int, error) {
 	nextEpoch, err := getNextEpoch(ctx, height)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	q := singleton.PoolsSDK.Query()
 	liquidAssets, err := q.AgentLiquidAssets(ctx, agent.AddressNative, big.NewInt(int64(nextEpoch)))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return liquidAssets, nil
+	interest, err := q.AgentInterestOwed(ctx, agent.AddressNative, big.NewInt(int64(nextEpoch)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return liquidAssets, interest, nil
 }

--- a/cmd/invariants/agentecon.go
+++ b/cmd/invariants/agentecon.go
@@ -12,119 +12,127 @@ import (
 	"github.com/spf13/viper"
 )
 
-// agentEconCmd represents the agentEcon command
-var agentEconCmd = &cobra.Command{
-	Use:   "agent-econ [agent-id] [--all] [--random <num>] [--epoch <epoch>]",
-	Short: "Compare the econ values from the API and the node for an agent",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
+// newAgentEconCmd: see agentbalances.go for the factory pattern.
+func newAgentEconCmd(use string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Compare the econ values from the API and the node for an agent",
+		Args:  cobra.MaximumNArgs(1),
+		Run:   runAgentEcon,
+	}
+	cmd.Flags().Uint64("epoch", 0, "Check at epoch")
+	cmd.Flags().Uint64("random", 0, "Randomly select agents")
+	cmd.Flags().Bool("all", false, "Check all agents")
+	return cmd
+}
 
-		eventsURL := viper.GetString("events_api")
+func runAgentEcon(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
 
-		err := initSingleton(ctx)
+	eventsURL := viper.GetString("events_api")
+
+	err := initSingleton(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	epoch, err := cmd.Flags().GetUint64("epoch")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	allAgents, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	randomAgents, err := cmd.Flags().GetUint64("random")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var failCount int
+
+	if !allAgents && randomAgents == 0 {
+		if len(args) != 1 {
+			cmd.Usage()
+			return
+		}
+
+		agentID, err := strconv.ParseUint(args[0], 10, 64)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		epoch, err := cmd.Flags().GetUint64("epoch")
+		agent, err := invariants.GetAgentFromAPI(ctx, eventsURL, agentID)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		allAgents, err := cmd.Flags().GetBool("all")
+		failed, err := checkAgentEcon(ctx, eventsURL, epoch, agent)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if failed {
+			failCount++
+		}
+	} else {
+		if len(args) != 0 {
+			cmd.Usage()
+			return
+		}
+
+		agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		randomAgents, err := cmd.Flags().GetUint64("random")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		var failCount int
-
-		if !allAgents && randomAgents == 0 {
-			if len(args) != 1 {
+		if allAgents {
+			if randomAgents > 0 {
 				cmd.Usage()
 				return
 			}
-
-			agentID, err := strconv.ParseUint(args[0], 10, 64)
-			if err != nil {
-				log.Fatal(err)
+			for _, agent := range agents {
+				failed, err := checkAgentEcon(ctx, eventsURL, epoch, &agent)
+				if err != nil {
+					log.Fatal(err)
+				}
+				if failed {
+					failCount++
+				}
 			}
-
-			agent, err := invariants.GetAgentFromAPI(ctx, eventsURL, agentID)
-			if err != nil {
-				log.Fatal(err)
+		} else if randomAgents > 0 {
+			if int(randomAgents) > len(agents) {
+				randomAgents = uint64(len(agents))
 			}
-
-			failed, err := checkAgentEcon(ctx, eventsURL, epoch, agent)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if failed {
-				failCount++
+			rand.Shuffle(len(agents), func(i, j int) {
+				agents[i], agents[j] = agents[j], agents[i]
+			})
+			for i := 0; i < int(randomAgents); i++ {
+				agent := agents[i]
+				failed, err := checkAgentEcon(ctx, eventsURL, epoch, &agent)
+				if err != nil {
+					log.Fatal(err)
+				}
+				if failed {
+					failCount++
+				}
 			}
 		} else {
-			if len(args) != 0 {
-				cmd.Usage()
-				return
-			}
-
-			agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			if allAgents {
-				if randomAgents > 0 {
-					cmd.Usage()
-					return
-				}
-				for _, agent := range agents {
-					failed, err := checkAgentEcon(ctx, eventsURL, epoch, &agent)
-					if err != nil {
-						log.Fatal(err)
-					}
-					if failed {
-						failCount++
-					}
-				}
-			} else if randomAgents > 0 {
-				if int(randomAgents) > len(agents) {
-					randomAgents = uint64(len(agents))
-				}
-				rand.Shuffle(len(agents), func(i, j int) {
-					agents[i], agents[j] = agents[j], agents[i]
-				})
-				for i := 0; i < int(randomAgents); i++ {
-					agent := agents[i]
-					failed, err := checkAgentEcon(ctx, eventsURL, epoch, &agent)
-					if err != nil {
-						log.Fatal(err)
-					}
-					if failed {
-						failCount++
-					}
-				}
-			} else {
-				cmd.Usage()
-			}
+			cmd.Usage()
 		}
+	}
 
-		if failCount > 0 {
-			log.Fatal("FAIL: Econ tests had errors.")
-		}
-	},
+	if failCount > 0 {
+		log.Fatal("FAIL: Econ tests had errors.")
+	}
 }
 
 func init() {
-	rootCmd.AddCommand(agentEconCmd)
-	agentEconCmd.Flags().Uint64("epoch", 0, "Check at epoch")
-	agentEconCmd.Flags().Uint64("random", 0, "Randomly select agents")
-	agentEconCmd.Flags().Bool("all", false, "Check all agents")
+	flat := newAgentEconCmd("agent-econ [agent-id] [--all] [--random <num>] [--epoch <epoch>]")
+	flat.Deprecated = "use `inv agent econ` instead"
+	rootCmd.AddCommand(flat)
+	agentCmd.AddCommand(newAgentEconCmd("econ [agent-id] [--all] [--random <num>] [--epoch <epoch>]"))
 }
 
 func checkAgentEcon(ctx context.Context, eventsURL string, epoch uint64, agent *invariants.Agent) (failed bool, err error) {

--- a/cmd/invariants/ifiltotalsupply.go
+++ b/cmd/invariants/ifiltotalsupply.go
@@ -10,64 +10,70 @@ import (
 	"github.com/spf13/viper"
 )
 
-// iFILTotalSupplyCmd represents the check-ifil-total-supply command
-var iFILTotalSupplyCmd = &cobra.Command{
-	Use:   "ifil-total-supply [--epoch <epoch>] [--find-missing]",
-	Short: "Compare the iFIL Total Supply from the API and the node",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
+func newPoolIfilCmd(use string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Compare the iFIL Total Supply from the API and the node",
+		Args:  cobra.NoArgs,
+		Run:   runPoolIfil,
+	}
+	cmd.Flags().Uint64("epoch", 0, "Check at epoch")
+	cmd.Flags().Bool("find-missing", false, "Find missing transactions")
+	return cmd
+}
 
-		eventsURL := viper.GetString("events_api")
+func runPoolIfil(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
 
-		err := initSingleton(ctx)
+	eventsURL := viper.GetString("events_api")
+
+	err := initSingleton(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	epoch, err := cmd.Flags().GetUint64("epoch")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	findMissing, err := cmd.Flags().GetBool("find-missing")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if epoch == 0 {
+		epoch, err = getHeadEpoch(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}
+		epoch = epoch - 2
+	}
 
-		epoch, err := cmd.Flags().GetUint64("epoch")
-		if err != nil {
-			log.Fatal(err)
-		}
+	apiTotalSupply, err := invariants.GetIFILTotalSupplyFromAPI(ctx, eventsURL, epoch)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-		findMissing, err := cmd.Flags().GetBool("find-missing")
-		if err != nil {
-			log.Fatal(err)
-		}
+	nodeTotalSupply, resultEpoch, err := invariants.GetIFILTotalSupplyFromNode(ctx, epoch)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-		if epoch == 0 {
-			epoch, err = getHeadEpoch(ctx)
-			if err != nil {
-				log.Fatal(err)
-			}
-			epoch = epoch - 2
-		}
+	// Mutate for testing
+	// nodeTotalSupply.IFILTotalSupply = big.NewInt(1234)
 
-		apiTotalSupply, err := invariants.GetIFILTotalSupplyFromAPI(ctx, eventsURL, epoch)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		nodeTotalSupply, resultEpoch, err := invariants.GetIFILTotalSupplyFromNode(ctx, epoch)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Mutate for testing
-		// nodeTotalSupply.IFILTotalSupply = big.NewInt(1234)
-
-		if apiTotalSupply.IFILTotalSupply.Cmp(nodeTotalSupply.IFILTotalSupply) == 0 {
-			fmt.Printf("@%d: Success, iFIL total supply matches: %v\n", epoch, apiTotalSupply.IFILTotalSupply)
-			return
-		}
-		fmt.Printf("@%d: Error, iFIL total supply from REST API doesn't match node.\n", epoch)
-		fmt.Printf("  Node @%d: %v\n", resultEpoch, nodeTotalSupply.IFILTotalSupply)
-		fmt.Printf("   API @%d: %v\n", epoch, apiTotalSupply.IFILTotalSupply)
-		if findMissing {
-			findMissingIFILEvents(ctx, eventsURL, epoch)
-		}
-		log.Fatal("FAIL: iFIL Total Supply test had errors.")
-	},
+	if apiTotalSupply.IFILTotalSupply.Cmp(nodeTotalSupply.IFILTotalSupply) == 0 {
+		fmt.Printf("@%d: Success, iFIL total supply matches: %v\n", epoch, apiTotalSupply.IFILTotalSupply)
+		return
+	}
+	fmt.Printf("@%d: Error, iFIL total supply from REST API doesn't match node.\n", epoch)
+	fmt.Printf("  Node @%d: %v\n", resultEpoch, nodeTotalSupply.IFILTotalSupply)
+	fmt.Printf("   API @%d: %v\n", epoch, apiTotalSupply.IFILTotalSupply)
+	if findMissing {
+		findMissingIFILEvents(ctx, eventsURL, epoch)
+	}
+	log.Fatal("FAIL: iFIL Total Supply test had errors.")
 }
 
 const step = 10000
@@ -141,7 +147,8 @@ func searchPassingIFILTotalSupply(ctx context.Context, eventsURL string, maxEpoc
 }
 
 func init() {
-	rootCmd.AddCommand(iFILTotalSupplyCmd)
-	iFILTotalSupplyCmd.Flags().Uint64("epoch", 0, "Check at epoch")
-	iFILTotalSupplyCmd.Flags().Bool("find-missing", false, "Find missing transactions")
+	flat := newPoolIfilCmd("ifil-total-supply [--epoch <epoch>] [--find-missing]")
+	flat.Deprecated = "use `inv pool ifil` instead"
+	rootCmd.AddCommand(flat)
+	poolCmd.AddCommand(newPoolIfilCmd("ifil [--epoch <epoch>] [--find-missing]"))
 }

--- a/cmd/invariants/metrics.go
+++ b/cmd/invariants/metrics.go
@@ -9,107 +9,114 @@ import (
 	"github.com/spf13/viper"
 )
 
-// metricsCmd represents the metrics command
-var metricsCmd = &cobra.Command{
-	Use:   "metrics [--epoch <epoch>]",
-	Short: "Compare the metrics from the API and the node at height",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
+func newPoolMetricsCmd(use string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Compare the metrics from the API and the node at height",
+		Args:  cobra.NoArgs,
+		Run:   runPoolMetrics,
+	}
+	cmd.Flags().Uint64("epoch", 0, "Check at epoch")
+	cmd.Flags().Bool("miner-count", false, "Check miner count (slow)")
+	return cmd
+}
 
-		chainID := viper.GetUint64("chain_id")
-		eventsURL := viper.GetString("events_api")
+func runPoolMetrics(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
 
-		fmt.Printf("ChainID: %v\n", chainID)
-		fmt.Printf("Events URL: %v\n", eventsURL)
+	chainID := viper.GetUint64("chain_id")
+	eventsURL := viper.GetString("events_api")
 
-		err := initSingleton(ctx)
+	fmt.Printf("ChainID: %v\n", chainID)
+	fmt.Printf("Events URL: %v\n", eventsURL)
+
+	err := initSingleton(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	epoch, err := cmd.Flags().GetUint64("epoch")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if epoch == 0 {
+		epoch, err = getHeadEpoch(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}
+		epoch = epoch - 3
+	}
 
-		epoch, err := cmd.Flags().GetUint64("epoch")
+	checkMinerCount, err := cmd.Flags().GetBool("miner-count")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	metricsFromAPI, err := invariants.GetMetricsFromAPIAtHeight(ctx, eventsURL, epoch)
+	if err != nil {
+		log.Fatal(err)
+	}
+	metricsFromNode, resultEpoch, err := invariants.GetMetricsFromNode(ctx, epoch)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var minerCountFromNode uint64
+	if checkMinerCount {
+		minerCountFromNode, resultEpoch, err = invariants.GetMinerCountFromNode(ctx, epoch)
 		if err != nil {
 			log.Fatal(err)
 		}
+	}
 
-		if epoch == 0 {
-			epoch, err = getHeadEpoch(ctx)
-			if err != nil {
-				log.Fatal(err)
-			}
-			epoch = epoch - 3
-		}
+	fail := false
 
-		checkMinerCount, err := cmd.Flags().GetBool("miner-count")
-		if err != nil {
-			log.Fatal(err)
-		}
+	if metricsFromAPI.PoolTotalAssets.Cmp(metricsFromNode.PoolTotalAssets) == 0 {
+		fmt.Printf("@%d: Success, pool total assets matches: %v\n", epoch, metricsFromAPI.PoolTotalAssets)
+	} else {
+		fmt.Printf("@%d: Error, pool total assets from REST API doesn't match node.\n", epoch)
+		fmt.Printf("  Node @%d: %v\n", resultEpoch, metricsFromNode.PoolTotalAssets)
+		fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.PoolTotalAssets)
+		fail = true
+	}
 
-		metricsFromAPI, err := invariants.GetMetricsFromAPIAtHeight(ctx, eventsURL, epoch)
-		if err != nil {
-			log.Fatal(err)
-		}
-		metricsFromNode, resultEpoch, err := invariants.GetMetricsFromNode(ctx, epoch)
-		if err != nil {
-			log.Fatal(err)
-		}
-		var minerCountFromNode uint64
-		if checkMinerCount {
-			minerCountFromNode, resultEpoch, err = invariants.GetMinerCountFromNode(ctx, epoch)
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
+	if metricsFromAPI.PoolTotalBorrowed.Cmp(metricsFromNode.PoolTotalBorrowed) == 0 {
+		fmt.Printf("@%d: Success, pool total borrowed matches: %v\n", epoch, metricsFromAPI.PoolTotalBorrowed)
+	} else {
+		fmt.Printf("@%d: Error, pool total borrowed from REST API doesn't match node.\n", epoch)
+		fmt.Printf("  Node @%d: %v\n", resultEpoch, metricsFromNode.PoolTotalBorrowed)
+		fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.PoolTotalBorrowed)
+		fail = true
+	}
 
-		fail := false
+	if metricsFromAPI.TotalAgentCount == metricsFromNode.TotalAgentCount {
+		fmt.Printf("@%d: Success, agent count matches: %v\n", epoch, metricsFromAPI.TotalAgentCount)
+	} else {
+		fmt.Printf("@%d: Error, agent count from REST API doesn't match node.\n", epoch)
+		fmt.Printf("  Node @%d: %v\n", resultEpoch, metricsFromNode.TotalAgentCount)
+		fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.TotalAgentCount)
+		fail = true
+	}
 
-		if metricsFromAPI.PoolTotalAssets.Cmp(metricsFromNode.PoolTotalAssets) == 0 {
-			fmt.Printf("@%d: Success, pool total assets matches: %v\n", epoch, metricsFromAPI.PoolTotalAssets)
+	if checkMinerCount {
+		if metricsFromAPI.TotalMinersCount == minerCountFromNode {
+			fmt.Printf("@%d: Success, miner count matches: %v\n", epoch, minerCountFromNode)
 		} else {
-			fmt.Printf("@%d: Error, pool total assets from REST API doesn't match node.\n", epoch)
-			fmt.Printf("  Node @%d: %v\n", resultEpoch, metricsFromNode.PoolTotalAssets)
-			fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.PoolTotalAssets)
+			fmt.Printf("@%d: Error, miner count from REST API doesn't match node.\n", epoch)
+			fmt.Printf("  Node @%d: %v\n", resultEpoch, minerCountFromNode)
+			fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.TotalMinersCount)
 			fail = true
 		}
+	}
 
-		if metricsFromAPI.PoolTotalBorrowed.Cmp(metricsFromNode.PoolTotalBorrowed) == 0 {
-			fmt.Printf("@%d: Success, pool total borrowed matches: %v\n", epoch, metricsFromAPI.PoolTotalBorrowed)
-		} else {
-			fmt.Printf("@%d: Error, pool total borrowed from REST API doesn't match node.\n", epoch)
-			fmt.Printf("  Node @%d: %v\n", resultEpoch, metricsFromNode.PoolTotalBorrowed)
-			fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.PoolTotalBorrowed)
-			fail = true
-		}
-
-		if metricsFromAPI.TotalAgentCount == metricsFromNode.TotalAgentCount {
-			fmt.Printf("@%d: Success, agent count matches: %v\n", epoch, metricsFromAPI.TotalAgentCount)
-		} else {
-			fmt.Printf("@%d: Error, agent count from REST API doesn't match node.\n", epoch)
-			fmt.Printf("  Node @%d: %v\n", resultEpoch, metricsFromNode.TotalAgentCount)
-			fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.TotalAgentCount)
-			fail = true
-		}
-
-		if checkMinerCount {
-			if metricsFromAPI.TotalMinersCount == minerCountFromNode {
-				fmt.Printf("@%d: Success, miner count matches: %v\n", epoch, minerCountFromNode)
-			} else {
-				fmt.Printf("@%d: Error, miner count from REST API doesn't match node.\n", epoch)
-				fmt.Printf("  Node @%d: %v\n", resultEpoch, minerCountFromNode)
-				fmt.Printf("   API @%d: %v\n", epoch, metricsFromAPI.TotalMinersCount)
-				fail = true
-			}
-		}
-
-		if fail {
-			log.Fatal("FAIL: Metrics tests had errors.")
-		}
-	},
+	if fail {
+		log.Fatal("FAIL: Metrics tests had errors.")
+	}
 }
 
 func init() {
-	rootCmd.AddCommand(metricsCmd)
-	metricsCmd.Flags().Uint64("epoch", 0, "Check at epoch")
-	metricsCmd.Flags().Bool("miner-count", false, "Check miner count (slow)")
+	flat := newPoolMetricsCmd("metrics [--epoch <epoch>]")
+	flat.Deprecated = "use `inv pool metrics` instead"
+	rootCmd.AddCommand(flat)
+	poolCmd.AddCommand(newPoolMetricsCmd("metrics [--epoch <epoch>]"))
 }

--- a/cmd/invariants/miner.go
+++ b/cmd/invariants/miner.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// minerCmd is the parent of every miner-level invariant check.
+//
+// Without a subcommand it runs every child check in sequence.
+// With a subcommand (`inv miner liquidation`, ...) it behaves
+// like cobra normally would.
+//
+// `inv miner-liquidation` stays as a deprecated alias.
+var minerCmd = &cobra.Command{
+	Use:   "miner",
+	Short: "Miner-level invariant checks",
+	Long: `Run every miner-level invariant check in sequence, or invoke a
+specific check via a subcommand:
+
+  inv miner             # all miner checks
+  inv miner liquidation # liquidation calc per-method`,
+	Run: runMinerAll,
+}
+
+// runMinerAll execs each child as a subprocess so a log.Fatal in one
+// check doesn't stop the others.
+func runMinerAll(cmd *cobra.Command, _ []string) {
+	var failed []string
+	for _, child := range cmd.Commands() {
+		if child.Name() == "help" {
+			continue
+		}
+		fmt.Printf("\n=== inv miner %s ===\n", child.Name())
+		c := exec.CommandContext(cmd.Context(), os.Args[0], "miner", child.Name())
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		c.Stdin = os.Stdin
+		if err := c.Run(); err != nil {
+			failed = append(failed, child.Name())
+		}
+	}
+	if len(failed) > 0 {
+		fmt.Printf("\n=== FAILED: %v ===\n", failed)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(minerCmd)
+}

--- a/cmd/invariants/minerliquidation.go
+++ b/cmd/invariants/minerliquidation.go
@@ -22,86 +22,120 @@ import (
 	"github.com/spf13/viper"
 )
 
-// minerLiquidationCmd represents the minerLiquidation command
-var minerLiquidationCmd = &cobra.Command{
-	Use:   "miner-liquidation [miner-id] [--agent <id>] [--random <num>] [--epoch <epoch>] [--progress] [--timeout duration]",
-	Short: "Compare liquidation values computed using various methods",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
+func newMinerLiquidationCmd(use string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Compare liquidation values computed using various methods",
+		Args:  cobra.MaximumNArgs(1),
+		Run:   runMinerLiquidation,
+	}
+	cmd.Flags().Uint64("epoch", 0, "Check at epoch")
+	cmd.Flags().Uint64("random", 0, "Randomly select miners")
+	cmd.Flags().Uint64("agent", 0, "Select only miners for a specific agent")
+	cmd.Flags().Bool("all-agents", false, "Loop over all agents")
+	cmd.Flags().Bool("progress", true, "Show progress bar")
+	cmd.Flags().Duration("timeout", time.Duration(15*time.Minute), "Stop query after timeout")
+	cmd.Flags().Float64("max-pct-variance", 5.0, "Acceptable percentage difference between quick and full methods")
+	return cmd
+}
 
-		timeout, err := cmd.Flags().GetDuration("timeout")
+func runMinerLiquidation(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	eventsURL := viper.GetString("events_api")
+
+	err = initSingleton(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	epoch, err := cmd.Flags().GetUint64("epoch")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if epoch == 0 {
+		epoch, err = getHeadEpoch(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}
-		ctx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
+		epoch = epoch - 3
+	}
 
-		eventsURL := viper.GetString("events_api")
+	agentID, err := cmd.Flags().GetUint64("agent")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-		err = initSingleton(ctx)
+	randomMiners, err := cmd.Flags().GetUint64("random")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	showProgress, err := cmd.Flags().GetBool("progress")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	allAgents, err := cmd.Flags().GetBool("all-agents")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	maxPctVariance, err := cmd.Flags().GetFloat64("max-pct-variance")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var failCount int
+
+	if allAgents {
+		agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		epoch, err := cmd.Flags().GetUint64("epoch")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if epoch == 0 {
-			epoch, err = getHeadEpoch(ctx)
+		for _, agent := range agents {
+			failed, err := checkTerminationsForAgent(ctx, eventsURL, agent.ID,
+				epoch, showProgress, maxPctVariance)
 			if err != nil {
 				log.Fatal(err)
 			}
-			epoch = epoch - 3
+			if failed {
+				failCount++
+			}
 		}
-
-		agentID, err := cmd.Flags().GetUint64("agent")
+	} else if agentID != 0 {
+		failed, err := checkTerminationsForAgent(ctx, eventsURL, agentID, epoch,
+			showProgress, maxPctVariance)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		randomMiners, err := cmd.Flags().GetUint64("random")
-		if err != nil {
-			log.Fatal(err)
+		if failed {
+			failCount++
 		}
+	} else {
+		if randomMiners == 0 {
+			if len(args) != 1 {
+				cmd.Usage()
+				return
+			}
 
-		showProgress, err := cmd.Flags().GetBool("progress")
-		if err != nil {
-			log.Fatal(err)
-		}
+			minerID := args[0]
 
-		allAgents, err := cmd.Flags().GetBool("all-agents")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		maxPctVariance, err := cmd.Flags().GetFloat64("max-pct-variance")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		var failCount int
-
-		if allAgents {
-			agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
+			miner, err := address.NewFromString(minerID)
 			if err != nil {
 				log.Fatal(err)
 			}
 
-			for _, agent := range agents {
-				failed, err := checkTerminationsForAgent(ctx, eventsURL, agent.ID,
-					epoch, showProgress, maxPctVariance)
-				if err != nil {
-					log.Fatal(err)
-				}
-				if failed {
-					failCount++
-				}
-			}
-		} else if agentID != 0 {
-			failed, err := checkTerminationsForAgent(ctx, eventsURL, agentID, epoch,
+			failed, err := checkTerminations(ctx, epoch, miner, nil, nil, "",
 				showProgress, maxPctVariance)
 			if err != nil {
 				log.Fatal(err)
@@ -110,102 +144,75 @@ var minerLiquidationCmd = &cobra.Command{
 				failCount++
 			}
 		} else {
-			if randomMiners == 0 {
-				if len(args) != 1 {
-					cmd.Usage()
-					return
-				}
+			if len(args) != 0 {
+				cmd.Usage()
+				return
+			}
 
-				minerID := args[0]
-
-				miner, err := address.NewFromString(minerID)
+			if randomMiners > 0 {
+				fmt.Println("Loading agents...")
+				agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
 				if err != nil {
 					log.Fatal(err)
 				}
 
-				failed, err := checkTerminations(ctx, epoch, miner, nil, nil, "",
-					showProgress, maxPctVariance)
-				if err != nil {
-					log.Fatal(err)
+				type AgentMiner struct {
+					agent *invariants.Agent
+					miner int
 				}
-				if failed {
-					failCount++
+				allMiners := make([]AgentMiner, 0)
+				for _, agent := range agents {
+					for i := 1; i <= int(agent.Miners); i++ {
+						allMiners = append(allMiners, AgentMiner{&agent, i})
+					}
 				}
-			} else {
-				if len(args) != 0 {
-					cmd.Usage()
-					return
-				}
+				fmt.Printf("%d miners loaded.\n", len(allMiners))
 
-				if randomMiners > 0 {
-					fmt.Println("Loading agents...")
-					agents, err := invariants.GetAgentsFromAPI(ctx, eventsURL)
+				if int(randomMiners) > len(allMiners) {
+					randomMiners = uint64(len(allMiners))
+				}
+				rand.Shuffle(len(agents), func(i, j int) {
+					allMiners[i], allMiners[j] = allMiners[j], allMiners[i]
+				})
+				for i := 0; i < int(randomMiners); i++ {
+					agentMiner := allMiners[i]
+					agent := agentMiner.agent
+					fmt.Printf("Agent %v @%d: %d miners, %0.3f FIL borrowed (via API)\n",
+						agent.ID, agent.Height, agent.Miners, util.ToFIL(agent.PrincipalBalance))
+
+					miners, err := invariants.GetAgentMinersFromAPI(ctx, eventsURL, agent.ID)
 					if err != nil {
 						log.Fatal(err)
 					}
-
-					type AgentMiner struct {
-						agent *invariants.Agent
-						miner int
-					}
-					allMiners := make([]AgentMiner, 0)
-					for _, agent := range agents {
-						for i := 1; i <= int(agent.Miners); i++ {
-							allMiners = append(allMiners, AgentMiner{&agent, i})
-						}
-					}
-					fmt.Printf("%d miners loaded.\n", len(allMiners))
-
-					if int(randomMiners) > len(allMiners) {
-						randomMiners = uint64(len(allMiners))
-					}
-					rand.Shuffle(len(agents), func(i, j int) {
-						allMiners[i], allMiners[j] = allMiners[j], allMiners[i]
-					})
-					for i := 0; i < int(randomMiners); i++ {
-						agentMiner := allMiners[i]
-						agent := agentMiner.agent
-						fmt.Printf("Agent %v @%d: %d miners, %0.3f FIL borrowed (via API)\n",
-							agent.ID, agent.Height, agent.Miners, util.ToFIL(agent.PrincipalBalance))
-
-						miners, err := invariants.GetAgentMinersFromAPI(ctx, eventsURL, agent.ID)
-						if err != nil {
-							log.Fatal(err)
-						}
-						for i, miner := range miners {
-							if i == agentMiner.miner-1 {
-								countStr := fmt.Sprintf("%d/%d", i+1, len(miners))
-								failed, err := checkTerminations(ctx, epoch, miner.MinerAddr,
-									agent, &miner, countStr, showProgress, maxPctVariance)
-								if err != nil {
-									log.Fatal(err)
-								}
-								if failed {
-									failCount++
-								}
+					for i, miner := range miners {
+						if i == agentMiner.miner-1 {
+							countStr := fmt.Sprintf("%d/%d", i+1, len(miners))
+							failed, err := checkTerminations(ctx, epoch, miner.MinerAddr,
+								agent, &miner, countStr, showProgress, maxPctVariance)
+							if err != nil {
+								log.Fatal(err)
+							}
+							if failed {
+								failCount++
 							}
 						}
 					}
-				} else {
-					cmd.Usage()
 				}
+			} else {
+				cmd.Usage()
 			}
 		}
-		if failCount > 0 {
-			log.Fatal("FAIL: Miner liquidation test had errors.")
-		}
-	},
+	}
+	if failCount > 0 {
+		log.Fatal("FAIL: Miner liquidation test had errors.")
+	}
 }
 
 func init() {
-	rootCmd.AddCommand(minerLiquidationCmd)
-	minerLiquidationCmd.Flags().Uint64("epoch", 0, "Check at epoch")
-	minerLiquidationCmd.Flags().Uint64("random", 0, "Randomly select miners")
-	minerLiquidationCmd.Flags().Uint64("agent", 0, "Select only miners for a specific agent")
-	minerLiquidationCmd.Flags().Bool("all-agents", false, "Loop over all agents")
-	minerLiquidationCmd.Flags().Bool("progress", true, "Show progress bar")
-	minerLiquidationCmd.Flags().Duration("timeout", time.Duration(15*time.Minute), "Stop query after timeout")
-	minerLiquidationCmd.Flags().Float64("max-pct-variance", 5.0, "Acceptable percentage difference between quick and full methods")
+	flat := newMinerLiquidationCmd("miner-liquidation [miner-id] [--agent <id>] [--random <num>] [--epoch <epoch>] [--progress] [--timeout duration]")
+	flat.Deprecated = "use `inv miner liquidation` instead"
+	rootCmd.AddCommand(flat)
+	minerCmd.AddCommand(newMinerLiquidationCmd("liquidation [miner-id] [--agent <id>] [--random <num>] [--epoch <epoch>] [--progress] [--timeout duration]"))
 }
 
 func checkTerminationsForAgent(

--- a/cmd/invariants/minerliquidation.go
+++ b/cmd/invariants/minerliquidation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/glifio/go-pools/econ"
 	"github.com/glifio/go-pools/terminate"
 	"github.com/glifio/go-pools/util"
 	"github.com/glifio/invariants"
@@ -275,14 +276,14 @@ func checkTerminations(
 
 	// Quick
 	start := time.Now()
-	quickResult, err := terminate.PreviewTerminateSectorsQuick(ctx, &lotus.Api, miner, ts)
+	quickResult, err := econ.EstimateTerminationFeeMiner(ctx, &lotus.Api, miner, ts)
 	if err != nil {
 		return true, err
 	}
 	elapsed := time.Since(start).Seconds()
 	fmt.Printf("%sMiner %s%v @%d: Quick method: %0.3f FIL (%d of %d sectors, offchain, %0.1fs)\n",
-		prefix, countStr, miner, epoch, util.ToFIL(quickResult.SectorStats.TerminationPenalty),
-		quickResult.SectorsTerminated, quickResult.SectorsCount, elapsed)
+		prefix, countStr, miner, epoch, util.ToFIL(quickResult.EstimatedTerminationFee),
+		quickResult.SampledSectors, quickResult.LiveSectors, elapsed)
 
 	// Sampled, onchain
 	var sampledResult *terminate.PreviewTerminateSectorsReturn
@@ -326,7 +327,7 @@ loopSampled:
 		}
 	}
 
-	if sampledResult.SectorStats.TerminationPenalty.Cmp(quickResult.SectorStats.TerminationPenalty) != 0 {
+	if sampledResult.SectorStats.TerminationPenalty.Cmp(quickResult.EstimatedTerminationFee) != 0 {
 		fmt.Printf("%sMiner %v%v: Assertion failed: Quick vs Sampled don't match\n",
 			prefix, countStr, miner)
 		failCount++
@@ -394,14 +395,14 @@ loopFull:
 	}
 
 	if minerDetails != nil {
-		apiDiff := new(big.Int).Sub(minerDetails.TerminationPenalty, quickResult.SectorStats.TerminationPenalty)
+		apiDiff := new(big.Int).Sub(minerDetails.TerminationPenalty, quickResult.EstimatedTerminationFee)
 		// For testing assertion
 		// apiDiff, _ = new(big.Int).SetString("650000000000000000", 10)
 		fmt.Printf("%sMiner %s%v: Termination penalty via API: %0.3f FIL\n",
 			prefix, countStr, miner, util.ToFIL(minerDetails.TerminationPenalty))
 
 		// Assert that db value from API is withing range
-		pctApi, _ := getPct(apiDiff, quickResult.SectorStats.TerminationPenalty, agent)
+		pctApi, _ := getPct(apiDiff, quickResult.EstimatedTerminationFee, agent)
 		if pctApi > maxPctVariance {
 			fmt.Printf("%sMiner %v%v: Assertion failed: API vs Quick %0.3f%% > %0.3f%%\n",
 				prefix, countStr, miner, pctApi, maxPctVariance)
@@ -412,12 +413,12 @@ loopFull:
 	// Variances
 	fullVsQuick := new(big.Int).Sub(
 		fullResult.SectorStats.TerminationPenalty,
-		quickResult.SectorStats.TerminationPenalty,
+		quickResult.EstimatedTerminationFee,
 	)
 
 	if fullVsQuick.Sign() == 0 {
 		fmt.Printf("%sMiner %s%v: Quick method and Full method agree (%d/%d sectors).\n",
-			prefix, countStr, miner, quickResult.SectorsTerminated, quickResult.SectorsCount)
+			prefix, countStr, miner, quickResult.SampledSectors, quickResult.LiveSectors)
 	} else {
 		var pctNum float64
 		var pctStr string
@@ -426,12 +427,12 @@ loopFull:
 			pctNum, pctStr = getPct(fullVsQuick, fullResult.SectorStats.TerminationPenalty, agent)
 			fmt.Printf("%sMiner %s%v: Quick method overestimated: %0.3f FIL (%s, %d/%d sectors)\n",
 				prefix, countStr, miner, util.ToFIL(fullVsQuick), pctStr,
-				quickResult.SectorsTerminated, quickResult.SectorsCount)
+				quickResult.SampledSectors, quickResult.LiveSectors)
 		} else {
 			pctNum, pctStr = getPct(fullVsQuick, fullResult.SectorStats.TerminationPenalty, agent)
 			fmt.Printf("%sMiner %s%v: Quick method UNDERESTIMATED: %0.3f FIL (%s, %d/%d sectors)\n",
 				prefix, countStr, miner, util.ToFIL(fullVsQuick), pctStr,
-				quickResult.SectorsTerminated, quickResult.SectorsCount)
+				quickResult.SampledSectors, quickResult.LiveSectors)
 		}
 		if pctNum > maxPctVariance {
 			fmt.Printf("%sMiner %v%v: Assertion failed: Quick vs Full diff %0.3f%% > %0.3f%%\n",

--- a/cmd/invariants/pool.go
+++ b/cmd/invariants/pool.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// poolCmd is the parent of every pool-level invariant check.
+//
+// Without a subcommand it runs every child check in sequence.
+// With a subcommand (`inv pool metrics`, `inv pool ifil`, ...) it
+// behaves like cobra normally would.
+//
+// Flat aliases (`inv metrics`, `inv ifil-total-supply`) stay as
+// deprecated entry points for one or two releases.
+var poolCmd = &cobra.Command{
+	Use:   "pool",
+	Short: "Pool-level invariant checks",
+	Long: `Run every pool-level invariant check in sequence, or invoke a
+specific check via a subcommand:
+
+  inv pool         # all pool checks
+  inv pool metrics # totalAssets / totalBorrowed / agentCount
+  inv pool ifil    # iFIL total supply`,
+	Run: runPoolAll,
+}
+
+// runPoolAll execs each child as a subprocess so a log.Fatal in one
+// check doesn't stop the others.
+func runPoolAll(cmd *cobra.Command, _ []string) {
+	var failed []string
+	for _, child := range cmd.Commands() {
+		if child.Name() == "help" {
+			continue
+		}
+		fmt.Printf("\n=== inv pool %s ===\n", child.Name())
+		c := exec.CommandContext(cmd.Context(), os.Args[0], "pool", child.Name())
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		c.Stdin = os.Stdin
+		if err := c.Run(); err != nil {
+			failed = append(failed, child.Name())
+		}
+	}
+	if len(failed) > 0 {
+		fmt.Printf("\n=== FAILED: %v ===\n", failed)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(poolCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/filecoin-project/go-jsonrpc v0.3.2
 	github.com/filecoin-project/go-state-types v0.14.0
 	github.com/filecoin-project/lotus v1.28.1
-	github.com/glifio/go-pools v1.0.3-0.20240807013523-4f5a1b525b15
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
@@ -60,6 +59,7 @@ require (
 	github.com/filecoin-project/specs-actors/v8 v8.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gbrlsnchs/jwt/v3 v3.0.1 // indirect
+	github.com/glifio/go-pools v1.0.4-0.20240903053507-d204955845ab // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+require github.com/glifio/go-pools v1.1.3
+
 require (
-	github.com/ALTree/bigfloat v0.0.0-20220102081255-38c8b72a9924 // indirect
 	github.com/GeertJohan/go.incremental v1.0.0 // indirect
 	github.com/GeertJohan/go.rice v1.0.3 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
@@ -59,7 +60,6 @@ require (
 	github.com/filecoin-project/specs-actors/v8 v8.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gbrlsnchs/jwt/v3 v3.0.1 // indirect
-	github.com/glifio/go-pools v1.0.4-0.20240903053507-d204955845ab // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/ALTree/bigfloat v0.0.0-20220102081255-38c8b72a9924 h1:DG4UyTVIujioxwJc8Zj8Nabz1L1wTgQ/xNBSQDfdP3I=
-github.com/ALTree/bigfloat v0.0.0-20220102081255-38c8b72a9924/go.mod h1:+NaH2gLeY6RPBPPQf4aRotPPStg+eXc8f9ZaE4vRfD4=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
@@ -182,10 +180,8 @@ github.com/gbrlsnchs/jwt/v3 v3.0.1 h1:lbUmgAKpxnClrKloyIwpxm4OuWeDl5wLk52G91ODPw
 github.com/gbrlsnchs/jwt/v3 v3.0.1/go.mod h1:AncDcjXz18xetI3A6STfXq2w+LuTx8pQ8bGEwRN8zVM=
 github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
 github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
-github.com/glifio/go-pools v1.0.3-0.20240807013523-4f5a1b525b15 h1:Zx3eLCJADQMaM4PtzaXJY5caujKa3Ol+XIL+7NqsHBA=
-github.com/glifio/go-pools v1.0.3-0.20240807013523-4f5a1b525b15/go.mod h1:jvk+Uo4ibxGQ9fN/LcykqLoXzfkRlSlbK4RLTfquzdk=
-github.com/glifio/go-pools v1.0.4-0.20240903053507-d204955845ab h1:ZfEhtvGPwtBkxFeoZZaCWGzfzhmzr8vcUPragJ4gZ1o=
-github.com/glifio/go-pools v1.0.4-0.20240903053507-d204955845ab/go.mod h1:G+JltF4457QvLCk8cIMLTHl6L7HgB515Bv8IRgFJJx8=
+github.com/glifio/go-pools v1.1.3 h1:o8lop9cckaxZ3P8UeWlk/GmlJLWhcQkiDIX9aDM82cA=
+github.com/glifio/go-pools v1.1.3/go.mod h1:G+JltF4457QvLCk8cIMLTHl6L7HgB515Bv8IRgFJJx8=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkN
 github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
 github.com/glifio/go-pools v1.0.3-0.20240807013523-4f5a1b525b15 h1:Zx3eLCJADQMaM4PtzaXJY5caujKa3Ol+XIL+7NqsHBA=
 github.com/glifio/go-pools v1.0.3-0.20240807013523-4f5a1b525b15/go.mod h1:jvk+Uo4ibxGQ9fN/LcykqLoXzfkRlSlbK4RLTfquzdk=
+github.com/glifio/go-pools v1.0.4-0.20240903053507-d204955845ab h1:ZfEhtvGPwtBkxFeoZZaCWGzfzhmzr8vcUPragJ4gZ1o=
+github.com/glifio/go-pools v1.0.4-0.20240903053507-d204955845ab/go.mod h1:G+JltF4457QvLCk8cIMLTHl6L7HgB515Bv8IRgFJJx8=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/metrics.go
+++ b/metrics.go
@@ -145,7 +145,7 @@ func GetMetricsFromNode(ctx context.Context, height uint64) (*MetricsResult, uin
 
 	infinityPool := sdk.Query().InfinityPool()
 
-	poolCaller, err := abigen.NewInfinityPoolCaller(infinityPool, ethClient)
+	poolCaller, err := abigen.NewInfinityPoolV2Caller(infinityPool, ethClient)
 	if err != nil {
 		return nil, height, err
 	}


### PR DESCRIPTION
## Summary
- Adds `inv agent`, `inv pool`, `inv miner` parent commands; existing checks become subcommands (`inv agent balances 97`, `inv pool metrics`, `inv miner liquidation`).
- Bare parent invocations sweep the whole domain — children are spawned as subprocesses so a `log.Fatal` in one check doesn't abort the rest, and a final `=== FAILED: [...] ===` line summarises losers.
- Old flat names (`inv agent-balances`, `inv metrics`, `inv ifil-total-supply`, `inv miner-liquidation`, `inv agent-econ`) stay as deprecated aliases via a factory pattern that registers each command under both names.
- Picks up phase-0 parallel + same-epoch pinning for `inv agent balances --all` and the go-pools v1.1.3 bump that lands with it.

## Test plan
- [x] `go build ./...`
- [x] `inv agent balances 97` — single-agent path
- [x] `inv agent-balances 97` — deprecated alias still works (warning emitted)
- [x] `inv pool` — runs `ifil` then `metrics`, both children failed independently and were reported in summary
- [ ] `inv agent` end-to-end (slow, deferred — single-agent and `--all` paths verified)
- [ ] `inv miner liquidation <miner-id>` regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)